### PR TITLE
Added configurable WebSocket Secure support.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ export interface ServerOptions {
    * Which port to listen to.  Default: 9090.
    */
   port: number
-
 }
 
 export interface PfxServerOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,36 @@ export interface ServerOptions {
    * Which port to listen to.  Default: 9090.
    */
   port: number
+
 }
+
+export interface PfxServerOptions {
+  /**
+   * Path to a PFX file.
+   */
+  pathToPfx: string
+  /**
+   * Passphrase, if required, of the PFX file.
+   */
+  passphrase?: string
+}
+
+export interface CertServerOptions {
+  /**
+   * Path to a signing cert file.
+   */
+  pathToCert: string
+  /**
+   * Path to a the corresponding key of the cert file.
+   */
+  pathToKey: string
+  /**
+   * Passphrase, if required, of the key file.
+   */
+  passphrase?: string
+}
+
+export type WssServerOptions = PfxServerOptions | CertServerOptions
 
 /**
  * A client which is in the process of connecting.

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ export interface ServerOptions {
    * Which port to listen to.  Default: 9090.
    */
   port: number
+
+  /**
+   * Web Socket Secure Configuration
+   */
+  wss?: WssServerOptions
 }
 
 export interface PfxServerOptions {


### PR DESCRIPTION
This is a configurable implementation for wss. It works by using https server for websocket server. 

Resolves #3 .

reactotron-react-js configuration:

```javascript
import reactotronReactJs from "reactotron-react-js"

const wsReplace = /ws:/
reactotronReactJs.configure({
  createSocket: path => new WebSocket(path.replace(wsReplace, "wss:"))
})
```
Powershell script to create a certificate for testing (Windows):

```powershell
$pfxPath = "<path to reactotron-app>\cert.pfx"

# Create cert in My Store
$cert = New-SelfSignedCertificate -DnsName localhost -FriendlyName "Local Websocket"

# Save cert to reactotron app path
$stream = [System.IO.File]::OpenWrite($pfxPath)
$certBytes = $cert.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx)
$stream.Write($certBytes, 0, $certBytes.Length)
$stream.Dispose()

# Trust the cert
Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\Root -FilePath $pfxPath
```