### PR TITLE
Removed log when disconnected

### DIFF
--- a/src/reactotron-core-server.ts
+++ b/src/reactotron-core-server.ts
@@ -180,7 +180,6 @@ export default class Server {
 
       // when this client disconnects
       socket.on("close", () => {
-        console.log('Client disconnected');
         // remove them from the list partial list
         this.partialConnections = reject(
           propEq("id", thisConnectionId),


### PR DESCRIPTION
There's no log on connect, so should not be one on disconnect. The user of the server can subscribe to events and log if necessary.